### PR TITLE
fix pagination label colour

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Adjusted the CSS of `.pageInfo` in the `issue-list` CSS module so that pagination colour matches design (Gray-700 rather than Gray-300).