### PR TITLE
open mail client when clicking Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,8 @@ yarn-error.log*
 .stylelintcache
 .env
 
+# Cypress test files
+*.cy.tsx
+
 # Cypress test videos
 cypress/videos/

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -11,4 +11,11 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+
+  component: {
+    devServer: {
+      framework: "next",
+      bundler: "webpack",
+    },
+  },
 });

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -42,6 +42,32 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    function parseMailto(mailtoString: string) {
+      const [mailto, params] = mailtoString.split("?");
+      const recipient = mailto.split(":")[1];
+      const result: { [index: string]: string } = { recipient };
+      params.split("&").forEach((param: string) => {
+        const [key, encoded] = param.split("=");
+        result[key] = decodeURIComponent(encoded);
+      });
+      return result;
+    }
+
+    it("support opens mail client", () => {
+      cy.get("nav")
+        .contains("Support")
+        .should("have.attr", "href")
+        .should("be.a", "string")
+        .as("mailtoString");
+      cy.get<string>("@mailtoString")
+        .then(parseMailto)
+        .then(console.log)
+        .should("deep.equal", {
+          recipient: "support@prolog-app.com",
+          subject: "Support Request:",
+        });
+    });
   });
 
   context("mobile resolution", () => {

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Components App</title>
+    <!-- Used by Next.js to inject CSS. -->
+    <div id="__next_css__DO_NOT_USE__"></div>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,11 +79,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              isActive={false}
+              href="mailto:support@prolog-app.com?subject=Support Request:"
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Changed Support link in nav to `MenuItemLink` instead of `MenuItemButton` to use `href` attribute to open mail client with `mailto` string.

This is to prevent unnecessary `window.open` in an `onClick` in a button, as well as easier to test in Cypress by checking directly against the `href` value and confirming if it is a correctly formatted `mailto` URL. (Cypress cannot test the mail client itself, so we must rely on testing for a correct `mailto` string under `href`.)