### PR TITLE
open mail client when clicking Support

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -42,6 +42,32 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    function parseMailto(mailtoString: string) {
+      const [mailto, params] = mailtoString.split("?");
+      const recipient = mailto.split(":")[1];
+      const result: { [index: string]: string } = { recipient };
+      params.split("&").forEach((param: string) => {
+        const [key, encoded] = param.split("=");
+        result[key] = decodeURIComponent(encoded);
+      });
+      return result;
+    }
+
+    it("support opens mail client", () => {
+      cy.get("nav")
+        .contains("Support")
+        .should("have.attr", "href")
+        .should("be.a", "string")
+        .as("mailtoString");
+      cy.get<string>("@mailtoString")
+        .then(parseMailto)
+        .then(console.log)
+        .should("deep.equal", {
+          recipient: "support@prolog-app.com",
+          subject: "Support Request:",
+        });
+    });
   });
 
   context("mobile resolution", () => {

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -36,7 +36,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -106,7 +106,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,11 +79,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              isActive={false}
+              href="mailto:support@prolog-app.com?subject=Support Request:"
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Open mail client with pre-populated subject line when clicking Support in navigation.

Changed the Support link component to `MenuItemLink` instead of `MenuItemButton` to be able to use `href` attribute with a `mailto` string. This is easier to test against with Cypress, since Cypress cannot test the mail client itself, so our test only checks for a correctly formatted `mailto` value under the `href` attribute.